### PR TITLE
Updated return structs, made all tests pass, added bundler tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 require 'rake/testtask'
+require 'bundler/gem_tasks'
 
 Rake::TestTask.new do |t|
   t.libs << 'test'

--- a/lib/osmn/structs.rb
+++ b/lib/osmn/structs.rb
@@ -11,14 +11,16 @@ module OSMN
     :class,
     :type,
     :importance,
-    :address)
+    :address,
+    :icon)
 
   Address = Struct.new(
     :house_number, 
     :road, 
     :suburb, 
     :city, 
-    :county, 
+    :county,
+    :continent, 
     :state_district, 
     :state, 
     :postcode, 

--- a/lib/osmn/version.rb
+++ b/lib/osmn/version.rb
@@ -1,3 +1,3 @@
 module OSMN
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end

--- a/osmn.gemspec
+++ b/osmn.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'json'
 
   gem.add_development_dependency 'rake'
+  gem.add_development_dependency "bundler", "~> 1.3"
 end

--- a/test/test_osmn.rb
+++ b/test/test_osmn.rb
@@ -15,12 +15,6 @@ class Tests < Test::Unit::TestCase
     assert_equal(nil, response)
   end
 
-  def test_search
-    response = OSMN::search('135 pilkington avenue, birmingham')[0]
-
-    assert_equal('62311100', response.place_id)
-  end
-
   def test_reverse
     response = OSMN::reverse_geocode(52.5487429714954, -1.81602098644987)
 
@@ -28,7 +22,9 @@ class Tests < Test::Unit::TestCase
   end
 
   def test_search
-    response = OSMN::search('135 pilkington avenue, birmingham', 0)[0]
+    response = OSMN::search('135 pilkington avenue, birmingham')[0]
+
+    assert_equal('62311100', response.place_id)
 
     assert_respond_to(response, :place_id)
     assert_respond_to(response, :licence)


### PR DESCRIPTION
This pull gets the tests to pass again (missing continent and icon from the result structs).  Also updated the version number and add bundler default tasks (so that you can do rake install and rake build).  It also looks like test_search was defined twice, so I consolidated that into a single test.

Thanks for writing this gem!
